### PR TITLE
changing from graph to tree format

### DIFF
--- a/utilities/makegraph.rkt
+++ b/utilities/makegraph.rkt
@@ -21,8 +21,7 @@
          remove-edge
          all-fields-set?
          add-target-to-makegraph
-         target-in-graph?
-         get-target)
+         target-in-graph?)
 
 (define EDGE 0) ;; edge counter. to create ordering on edges
 (define (get-edge-id)
@@ -129,14 +128,14 @@
       (set-target-in-edges! t (insert-edge e (target-in-edges t)))))
 
 ;; adds a recipe edge
-(define (add-recipe t recipe recipe-t info)
-  (define tmp (edge recipe info 'seq (get-edge-id)))
+(define (add-recipe t recipe-t info)
+  (define tmp (edge recipe-t info 'seq (get-edge-id)))
   (set-target-in-edges! recipe-t (cons tmp (target-in-edges recipe-t)))
   (set-target-out-edges! t (cons tmp (target-out-edges t))))
 
 ;; adds a dependency edge
-(define (add-dependency t dep dep-t info)
-  (define tmp (edge dep info 'dep (get-edge-id)))
+(define (add-dependency t dep-t info)
+  (define tmp (edge dep-t info 'dep (get-edge-id)))
   (set-target-in-edges! dep-t (cons tmp (target-in-edges dep-t)))
   (set-target-out-edges! t (cons tmp (target-out-edges t))))
 
@@ -166,17 +165,12 @@
 (define (create-makegraph)
   (makegraph (make-hash) #f))
 
-(define (add-target-to-makegraph graph tid t)
-  (hash-set! (makegraph-targets graph) tid t))
+(define (add-target-to-makegraph graph t)
+  (hash-set! (makegraph-targets graph) t #t))
 
-(define (target-in-graph? graph tid)
-  (if (hash-ref (makegraph-targets graph) tid #f)
-      #t
-      #f))
-
-(define (get-target graph tid)
-  (hash-ref (makegraph-targets graph) tid #f))
-
+(define (target-in-graph? graph t)
+  (hash-ref (makegraph-targets graph) t #f))
+ 
 ;; -------------- end make graph code --------------------------
 
 ;; -------------- structure to represent rusage data -----------


### PR DESCRIPTION
This branch moves us from producing a directed graph to producing a tree.  The produced graphs are not meant to have cycles but sometimes the make output is misunderstood and targets are misinterpreted as the same when they are not.  This can result in erroneous cycles.  To produce a tree rather than a graph we create a new target struct instance each time we encounter a target rather than share a single target struct instance across each reference to a unique target.  This change also simplifies some algorithms that operate on the produced graph.  This change should also reduce future issues caused by misunderstood make output. 